### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHNAGELOG.md
+++ b/CHNAGELOG.md
@@ -1,4 +1,4 @@
-#Change Log
+# Change Log
 Version 1.1.2 *(2015-10-14)*
 ----------------------------
 * add method setViewPager(ViewPager vp, String[] titles)  for the condition that you do not want set titles in page adapter 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#FlycoTabLayout
+# FlycoTabLayout
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-FlycoTabLayout-green.svg?style=true)](https://android-arsenal.com/details/1/2756)
-####[中文版](https://github.com/H07000223/FlycoTabLayout/blob/master/README_CN.md)
+#### [中文版](https://github.com/H07000223/FlycoTabLayout/blob/master/README_CN.md)
 An Android TabLayout Lib has 3 kinds of TabLayout at present.
 
 * SlidingTabLayout: deeply modified from [PagerSlidingTabStrip](https://github.com/jpardogo/PagerSlidingTabStrip).
@@ -31,7 +31,7 @@ can be used freely with other widgets together.
 
 * SegmentTabLayout
 
-##Demo
+## Demo
 ![](https://github.com/H07000223/FlycoTabLayout/blob/master/preview_1.gif)
 
 ![](https://github.com/H07000223/FlycoTabLayout/blob/master/preview_2.gif)
@@ -49,7 +49,7 @@ can be used freely with other widgets together.
    - remove the dependence of NineOldAnimation(only support 3.0+)
 
 
-##Gradle
+## Gradle
 
 ```groovy
 dependencies{
@@ -73,7 +73,7 @@ dependencies{
 }
 ```
 
-##Attributes
+## Attributes
 
 |name|format|description|
 |:---:|:---:|:---:|
@@ -110,9 +110,9 @@ dependencies{
 | tl_indicator_bounce_enable |boolean| set indicator aniamtion with bounce effect(only for CommonTabLayout)
 | tl_indicator_width_equal_title |boolean| set indicator width same as text(only for SlidingTabLayout)
 
-##Dependence
+## Dependence
 *   [NineOldAndroids](https://github.com/JakeWharton/NineOldAndroids)
 *   [FlycoRoundView](https://github.com/H07000223/FlycoRoundView)
 
-##Thanks
+## Thanks
 *   [PagerSlidingTabStrip](https://github.com/jpardogo/PagerSlidingTabStrip)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,4 +1,4 @@
-#FlycoTabLayout
+# FlycoTabLayout
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-FlycoTabLayout-green.svg?style=true)](https://android-arsenal.com/details/1/2756)
 
 一个Android TabLayout库,目前有3个TabLayout
@@ -30,7 +30,7 @@
 
 * SegmentTabLayout
 
-##Demo
+## Demo
 ![](https://github.com/H07000223/FlycoTabLayout/blob/master/preview_1.gif)
 
 ![](https://github.com/H07000223/FlycoTabLayout/blob/master/preview_2.gif)
@@ -47,7 +47,7 @@
  > v2.0.2(2016-04-23)
    - 删除了对NineOldAnimation库依赖(仅支持3.0+)
 
-##Gradle
+## Gradle
 
 ```groovy
 dependencies{
@@ -71,7 +71,7 @@ dependencies{
 }
 ```
 
-##Attributes
+## Attributes
 
 |name|format|description|
 |:---:|:---:|:---:|
@@ -108,9 +108,9 @@ dependencies{
 | tl_indicator_bounce_enable |boolean| 设置显示器支持动画回弹效果(only for CommonTabLayout)
 | tl_indicator_width_equal_title |boolean| 设置显示器与标题一样长(only for SlidingTabLayout)
 
-##Dependence
+## Dependence
 *   [NineOldAndroids](https://github.com/JakeWharton/NineOldAndroids)
 *   [FlycoRoundView](https://github.com/H07000223/FlycoRoundView)
 
-##Thanks
+## Thanks
 *   [PagerSlidingTabStrip](https://github.com/jpardogo/PagerSlidingTabStrip)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
