### PR TITLE
Fix bug: setFakeBoldText not working in some cases

### DIFF
--- a/FlycoTabLayout_Lib/src/main/java/com/flyco/tablayout/SlidingTabLayout.java
+++ b/FlycoTabLayout_Lib/src/main/java/com/flyco/tablayout/SlidingTabLayout.java
@@ -308,7 +308,10 @@ public class SlidingTabLayout extends HorizontalScrollView implements ViewPager.
                     tv_tab_title.getPaint().setFakeBoldText(true);
                 } else if (mTextBold == TEXT_BOLD_NONE) {
                     tv_tab_title.getPaint().setFakeBoldText(false);
+                } else if (mTextBold == TEXT_BOLD_WHEN_SELECT) {
+                    tv_tab_title.getPaint().setFakeBoldText(i == mCurrentTab);
                 }
+                tv_tab_title.invalidate();
             }
         }
     }
@@ -371,6 +374,7 @@ public class SlidingTabLayout extends HorizontalScrollView implements ViewPager.
                 tab_title.setTextColor(isSelect ? mTextSelectColor : mTextUnselectColor);
                 if (mTextBold == TEXT_BOLD_WHEN_SELECT) {
                     tab_title.getPaint().setFakeBoldText(isSelect);
+                    tab_title.invalidate();
                 }
             }
         }


### PR DESCRIPTION
1. Selected text should be bold when SlidingTabLayout init in mode TEXT_BOLD_WHEN_SELECT(see Issue #286)
2. TextView should invalidate after setFakeBoldText to avoid not working in some cases